### PR TITLE
fix: resolve profile validation bug with connection_name field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "snowcli-tools"
-version = "1.4.0"
+version = "1.4.1"
 description = "Snowflake CLI Tools: generate a Data Catalog and Dependency Graph on top of the official Snowflake CLI; includes parallel query helpers and advanced lineage features"
 readme = "README.md"
 authors = [

--- a/src/snowcli_tools/mcp_server.py
+++ b/src/snowcli_tools/mcp_server.py
@@ -139,9 +139,9 @@ class SnowflakeMCPServer:
             ) from exc
 
         profile_names = {
-            conn.get("name")
+            (conn.get("name") or conn.get("connection_name"))
             for conn in connections
-            if isinstance(conn, dict) and conn.get("name")
+            if isinstance(conn, dict) and (conn.get("name") or conn.get("connection_name"))
         }
 
         if profile not in profile_names:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -701,6 +701,29 @@ class TestMCPInitializationFailures:
         result = await server._verify_components()
         assert result is False
 
+    @pytest.mark.asyncio
+    async def test_verify_components_with_connection_name_field(self, server):
+        """Test component verification works with connection_name field instead of name."""
+        server.config.snowflake.profile = "test-profile"
+        # Use connection_name field instead of name field
+        server.snow_cli.list_connections.return_value = [{"connection_name": "test-profile"}]
+
+        result = await server._verify_components()
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_verify_components_mixed_connection_fields(self, server):
+        """Test component verification with mixed name/connection_name fields."""
+        server.config.snowflake.profile = "test-profile"
+        server.snow_cli.list_connections.return_value = [
+            {"name": "other-profile"},
+            {"connection_name": "test-profile"},
+            {"name": "another-profile"}
+        ]
+
+        result = await server._verify_components()
+        assert result is True
+
     def test_error_message_sanitization(self):
         """Test that error messages are properly sanitized."""
         # This would be tested in an integration test, but we can test the concept

--- a/uv.lock
+++ b/uv.lock
@@ -1296,7 +1296,7 @@ wheels = [
 
 [[package]]
 name = "snowcli-tools"
-version = "1.3.2"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Fix validation logic to check both 'name' and 'connection_name' fields in profile validation
- Add comprehensive tests for connection_name field validation scenarios
- Add test coverage for mixed connection field scenarios

## Problem
The MCP server startup validation was failing when Snowflake CLI returns connections with 'connection_name' field instead of 'name' field. The validation code only checked for 'name', causing startup failures even when the profile exists.

## Solution
Updated the profile validation in `_validate_configuration_schema()` to check both field names, matching the existing behavior in `connection_exists()` method.

## Test Plan
- [x] Added test for connections using 'connection_name' field
- [x] Added test for mixed 'name'/'connection_name' scenarios
- [x] Existing tests continue to pass
- [x] Validation now works with both field formats

🤖 Generated with [Claude Code](https://claude.ai/code)